### PR TITLE
Allow setting URL redirect HTTP response code

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ module "www_example" {
 | host_redirect  | The name of the target domain to redirect | string |
 | https_redirect | Issue TLS certificate and enable HTTPS | bool |
 | strip_query    | Strip URL query parameters | bool |
+| redirect_response_code | HTTP status code to use for the redirect | [string](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_url_map#redirect_response_code) |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -30,9 +30,10 @@ resource "google_compute_url_map" "http_url_map" {
   name = "${local.safe_hostname}-to-http-url-map"
 
   default_url_redirect {
-    host_redirect  = var.host_redirect
-    https_redirect = var.https_redirect
-    strip_query    = var.strip_query
+    host_redirect          = var.host_redirect
+    https_redirect         = var.https_redirect
+    strip_query            = var.strip_query
+    redirect_response_code = var.redirect_response_code
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -19,3 +19,9 @@ variable "strip_query" {
   type        = bool
   default     = false
 }
+
+variable "redirect_response_code" {
+  description = "HTTP status code to use for the redirect"
+  type        = string
+  default     = "MOVED_PERMANENTLY_DEFAULT"
+}


### PR DESCRIPTION
This gives flexibility, for example to return a 302 when the redirect destination is likely to change in the future.